### PR TITLE
Documentation overhaul, hotfix for getNewTokens

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -26,6 +26,9 @@
         "href": "https://github.com/Prouser123/parkrun.js",
         "target": "_blank",
         "class": "menu-item"
+      },
+      "<h3>Main Class</h3></a></h2><ul><li><a href='./parkrun.html'>Parkrun</a></li></ul>": {
+        "href": "./parkrun.html"
       }
     }
   }

--- a/src/classes/Country.js
+++ b/src/classes/Country.js
@@ -1,9 +1,5 @@
 /**
  * A class representing a parkrun country.
- *
- *
- * @borrows Parkrun#getAllEventsByCountry as getAllEvents
- * @borrows Parkrun#getAllEventNamesByCountry() as getAllEventNames
  */
 class Country {
   constructor(res, core) {
@@ -23,8 +19,8 @@ class Country {
    * Get an array of all the events in this country.
    *
    *
-   * @see Parkrun#getAllEventsByCountry()
-   * @see Parkrun#getAllEvents()
+   * @see (Borrows from {@link Parkrun#getAllEventsByCountry})
+   * @see Parkrun#getAllEvents
    *
    * @returns {Promise<Array<Event>>}
    * @throws {ParkrunNetError} ParkrunJS Networking Error.
@@ -36,8 +32,8 @@ class Country {
   /**
    * Get an array with the names of all parkrun events in this country, in alphabetical order.
    *
-   * @see Parkrun#getAllEventNames()
-   * @see Parkrun#getAllEventNamesByCountry()
+   * @see (Borrows from {@link Parkrun#getAllEventNamesByCountry})
+   * @see Parkrun#getAllEventNames
    *
    * @returns {Promise<Array<String>>}
    * @throws {ParkrunNetError} ParkrunJS Networking Error.

--- a/src/classes/Event.js
+++ b/src/classes/Event.js
@@ -8,10 +8,6 @@ const RosterVolunteer = require("./RosterVolunteer");
 
 /**
  *  A class representing a Parkrun event.
- *
- * @borrows Parkrun#getNews as getNews
- * @borrows Parkrun#getRoster as getRoster
- * @borrows Parkrun#getStatsByEvent as getStats
  */
 class Event {
   constructor(res, core) {
@@ -44,7 +40,7 @@ class Event {
   /**
    * Get all news posts for this event.
    *
-   * @see Parkrun#getNews()
+   * @see (Borrows from {@link Parkrun#getNews})
    *
    * @returns {Promise<Array<EventNewsPost>>} Array of news posts.
    * @throws {ParkrunNetError} ParkrunJS Networking Error.
@@ -56,7 +52,7 @@ class Event {
   /**
    * Get the upcoming roster(s) for this event.
    *
-   * @see Parkrun#getRoster()
+   * @see (Borrows from {@link Parkrun#getRoster})
    *
    * @returns {Promise<Array<RosterVolunteer>>}
    * @throws {ParkrunNetError} ParkrunJS Networking Error.
@@ -68,8 +64,8 @@ class Event {
   /**
    * Get statistics across a parkrun event.
    *
+   * @see (Borrows from {@link Parkrun#getStatsByEvent})
    * @see Parkrun#getStats
-   * @see Parkrun#getStatsByEvent
    *
    * @returns {Promise<Object>} statistics.
    * @throws {ParkrunNetError} ParkrunJS Networking Error.
@@ -151,7 +147,7 @@ class Event {
   /**
    * Get the Numerical Series ID for this event.
    *
-   * @see getEventDay for this value as a string.
+   * @see {@link Event#getEventDay} for this value as a string.
    * @returns {Number} Series ID.
    */
   getSeriesID() {
@@ -188,9 +184,10 @@ class Event {
   /**
    * Get the office email for this event.
    *
+   * Only available when this class is constructed via {@link Parkrun#getEvent}.
+   *
    * @returns {String} Office Email.
-   * @throws {ParkrunDataNotAvailableError} When not using ParkrunJS.getEvent(), this value is not provided and trying to access it will result in this error.
-   * @see Parkrun#getEvent()
+   * @throws {ParkrunDataNotAvailableError} When not using {@link Parkrun#getEvent}, this value is not provided and trying to access it will result in this error.
    */
   getOfficeEmail() {
     if (this._officeEmail == undefined)
@@ -203,9 +200,10 @@ class Event {
   /**
    * Get the helper email for this event.
    *
+   * Only available when this class is constructed via {@link Parkrun#getEvent}.
+   *
    * @returns {String} Helper Email.
-   * @throws {ParkrunDataNotAvailableError} When not using ParkrunJS.getEvent(), this value is not provided and trying to access it will result in this error.
-   * @see Parkrun#getEvent()
+   * @throws {ParkrunDataNotAvailableError} When not using {@link Parkrun#getEvent}, this value is not provided and trying to access it will result in this error.
    */
   getHelperEmail() {
     if (this._helperEmail == undefined)
@@ -218,9 +216,10 @@ class Event {
   /**
    * Get the amount of sessions that have taken place at this event.
    *
+   * Only available when this class is constructed via {@link Parkrun#getEvent}.
+   *
    * @returns {Number} No. of sessions taken place.
-   * @throws {ParkrunDataNotAvailableError} When not using ParkrunJS.getEvent(), this value is not provided and trying to access it will result in this error.
-   * @see Parkrun#getEvent()
+   * @throws {ParkrunDataNotAvailableError} When not using {@link Parkrun#getEvent}, this value is not provided and trying to access it will result in this error.
    */
   getTotalCount() {
     if (isNaN(this._totalEvents))

--- a/src/classes/FreedomRunResult.js
+++ b/src/classes/FreedomRunResult.js
@@ -1,7 +1,5 @@
 /**
  * A class representing the Results of a Freedom Run.
- *
- * @borrows Parkrun#getEvent as getEvent
  */
 class FreedomRunResult {
   constructor(res, core) {
@@ -31,7 +29,7 @@ class FreedomRunResult {
   /**
    * Get the event object for the event this took place at.
    *
-   * @see Parkrun#getEvent()
+   * @see (Borrows from {@link Parkrun#getEvent})
    *
    * @returns {Promise<Event>} Array of news posts.
    * @throws {ParkrunNetError} ParkrunJS Networking Error.

--- a/src/classes/RunResult.js
+++ b/src/classes/RunResult.js
@@ -1,6 +1,6 @@
 const { getDisplayName } = require("../common/AgeGradeEnums");
 
-const SeriesID = require("../common/SeriesID")
+const SeriesID = require("../common/SeriesID");
 
 /*
 
@@ -206,7 +206,7 @@ class RunResult {
    * Get weather this run was a PB.
    *
    * @returns {Boolean} Was PB?
-   * @see getWasGenuinePB() for a more accurate result.
+   * @see {@link RunResult#getWasGenuinePB} for a more accurate result.
    */
   getWasPB() {
     return this._was_pb;
@@ -214,12 +214,12 @@ class RunResult {
 
   /**
    * Get the numerical series ID for this run / event.
-   * 
-   * @see getEventDay for this value as a string.
+   *
+   * @see {@link RunResult#getEventDay} for this value as a string.
    * @returns {Number} Series ID.
    */
   getSeriesID() {
-    return this._series_id
+    return this._series_id;
   }
 
   /**
@@ -228,7 +228,7 @@ class RunResult {
    * @returns {"Saturday" | "Sunday" | "Unknown"} String day.
    */
   getEventDay() {
-    return SeriesID.getDayOfWeek(this.getSeriesID())
+    return SeriesID.getDayOfWeek(this.getSeriesID());
   }
 }
 

--- a/src/classes/Tokens.js
+++ b/src/classes/Tokens.js
@@ -72,6 +72,8 @@ class Tokens {
   /**
    * Get a VALID API Access Token, issuing a new token if needed.
    *
+   * When resolved, the new token (if needed) is also saved to getCurrentAccessToken()
+   *
    * @returns {Promise<String>} A promise containing a valid access token.
    *
    * @throws {Error} General error during token refresh

--- a/src/classes/Tokens.js
+++ b/src/classes/Tokens.js
@@ -26,7 +26,7 @@ class Tokens {
    *
    * This function is __not recommended__ for use as the response may be invalid. No checks are peformed here.
    *
-   * @see getValidAccessToken() to get a valid access token.
+   * @see {@link Tokens#getValidAccessToken} to get a valid access token.
    *
    * @returns {String} Access token.
    */
@@ -72,7 +72,7 @@ class Tokens {
   /**
    * Get a VALID API Access Token, issuing a new token if needed.
    *
-   * When resolved, the new token (if needed) is also saved to getCurrentAccessToken()
+   * When resolved, the new token (if needed) is also saved to {@link Tokens#getCurrentAccessToken}
    *
    * @returns {Promise<String>} A promise containing a valid access token.
    *

--- a/src/classes/User.js
+++ b/src/classes/User.js
@@ -17,8 +17,6 @@ const capitalize = str =>
 
 /**
  * A class representing a Parkrun User.
- *
- * @borrows Parkrun#getAthleteParkruns as getEvents
  */
 class User {
   /**
@@ -216,9 +214,9 @@ class User {
     };
   }
   /**
-   * Get an array of @see Event objects for each parkrun that the athlete has run, in alphabetical order.
+   * Get an array of {@link Event} objects for each parkrun that the athlete has run, in alphabetical order.
    *
-   * @see Parkrun#getAthleteParkruns
+   * @see (Borrows from {@link Parkrun#getAthleteParkruns})
    *
    * @returns {Promise<Array<Event>>}
    * @throws {ParkrunNetError} ParkrunJS Networking Error.

--- a/src/classes/User.js
+++ b/src/classes/User.js
@@ -168,10 +168,27 @@ class User {
     return out;
   }
 
+  // TypeDef for getClubs()
+  /**
+   * @typedef {Object} clubsResult
+   *
+   * @property {Object} ParkrunClub
+   * @property {String} ParkrunClub.id
+   * @property {String} ParkrunClub.name
+   *
+   * @property {Object} JuniorClub
+   * @property {String} JuniorClub.id
+   * @property {String} JuniorClub.name
+   *
+   * @property {Object} VolunteerClub
+   * @property {String} VolunteerClub.id
+   * @property {String} VolunteerClub.name
+   */
+
   /**
    * Get the user's Parkrun Clubs (for milestone runs / duties)
    *
-   * @returns {Promise<Object>}
+   * @returns {Promise<clubsResult>}
    * @throws {ParkrunNetError} ParkrunJS Networking Error.
    * @throws {ParkrunDataNotAvailableError} Error when no data is available, usually because of a new account with no runs.
    *

--- a/src/classes/parkrun.js
+++ b/src/classes/parkrun.js
@@ -23,8 +23,6 @@ const ClassList = require("../class_list");
 
 /**
  * The main hub for interacting with the Parkrun API.
- *
- * @module ParkrunJS
  */
 class Parkrun {
   /**
@@ -109,7 +107,7 @@ class Parkrun {
    *
    * Please note that **no authentication** checks are handled here.
    *
-   * @see {Parkrun#authRefresh} instead for an actual authentication method.
+   * @see {@link Parkrun.authRefresh} instead for an actual authentication method.
    *
    * @deprecated This method was meant for legacy users, and has a better alternative available. However, it will be included for the forseeable future.
    *
@@ -419,7 +417,13 @@ class Parkrun {
   async getAllEventNames() {
     return await this._getArrayOfAllEventNamesUsingURL("/v1/searchEvents");
   }
-
+  /**
+   * Get an array with the names of all parkrun events in the specified country, in alphabetical order.
+   *
+   * @param {Number} countryID Country ID.
+   * @returns {Promise<Array<String>>}
+   * @throws {ParkrunNetError} ParkrunJS Networking Error.
+   */
   async getAllEventNamesByCountry(countryID) {
     return await this._getArrayOfAllEventNamesUsingURL(
       `/v1/countries/${countryID}/searchEvents`
@@ -536,7 +540,7 @@ class Parkrun {
   }
 
   /**
-   * Get an array of @see Event objects for each parkrun that the specified athlete has run, in alphabetical order.
+   * Get an array of {@link Event} objects for each parkrun that the specified athlete has run, in alphabetical order.
    *
    * (Needed for freedomRuns)
    *


### PR DESCRIPTION
Also looks like 7a9f4dc's saucelabs timeouts were an anomaly, but we should monitor that just in case.

## PR Details

**🏠 Internal**

- **Deprecated** `[Parkrun].recreateTokens`, better alternative now available.

- Documentation overhaul
  - Improved main class navigation
  - Fixed all broken reference links
  - Fixed `@borrows` JSDoc issue causing duplicates
  - Removed that pesky module declaration

<br>

**🐛 Bug Fixes**

- Hotfix for `[Tokens].getNewTokens()` after `[Parkrun]`'s constructor call
  - e.g. when requesting new tokens after startup

<br><details><summary><b>Legend</b></summary>

`[ ___ ]` - Square brackets around a string indicate a class name.

- *example* `[ClientUser]` - referrers to the '[ClientUser](https://parkrun.js.org/ClientUser.html)' class.

</details>